### PR TITLE
Fix workaround URL when script_usbmount fails

### DIFF
--- a/scripts-startup.sh
+++ b/scripts-startup.sh
@@ -84,7 +84,7 @@ case "$1" in
                 echo "Everything looks good!"
             else
                 echo "Failure - firmware erased the value!"
-                echo "You will have to use a workaround - https://github.com/jacklul/asuswrt-scripts/master/asusware-usbmount"
+                echo "You will have to use a workaround - https://github.com/jacklul/asuswrt-scripts/tree/master/asusware-usbmount"
             fi
         fi
     ;;


### PR DESCRIPTION
This PR fixes the URL presented to the user when script_usbmount fails. The link currently `https://github.com/jacklul/asuswrt-scripts/master/asusware-usbmount` leads to a 404.