### PR TITLE
Fix wgs-lan-only.sh stop action using remove_iptables_rules_by_comment

### DIFF
--- a/scripts/wgs-lan-only.sh
+++ b/scripts/wgs-lan-only.sh
@@ -56,7 +56,7 @@ firewall_rules() {
                 done
             ;;
             "remove")
-                 "$_iptables" "filter" && _rules_action=-1
+                remove_iptables_rules_by_comment "$_iptables" "filter" && _rules_action=-1
             ;;
         esac
     done


### PR DESCRIPTION
when using the wgs-lan-only.sh script with the current version
run `/jffs/scripts/jas/wgs-lan-only.sh stop` returns
```
Bad argument `filter'
Try `iptables -h' or 'iptables --help' for more information.
Bad argument `filter'
Try `ip6tables -h' or 'ip6tables --help' for more information.
```